### PR TITLE
procd: fix wrong procd service_status

### DIFF
--- a/package/system/procd/files/procd.sh
+++ b/package/system/procd/files/procd.sh
@@ -524,7 +524,7 @@ _procd_send_signal() {
 _procd_status() {
 	local service="$1"
 	local instance="$2"
-	local data
+	local data running
 
 	json_init
 	[ -n "$service" ] && json_add_string name "$service"
@@ -542,6 +542,8 @@ _procd_status() {
 	if [ -z "$(echo "$data" | jsonfilter -e '$['"$instance"']')" ]; then
 		echo "unknown instance $instance"; return 4
 	else
+		running=$(echo "$data" | jsonfilter -e '@[*].running')
+		echo "$running" | grep -q true || { echo "inactive"; return 3; }
 		echo "running"; return 0
 	fi
 }


### PR DESCRIPTION
When a service runs with multiple instances and If service instances are killed at any time, Its status is listed as `"running": false` in `ubus call service list` output. Even though it's inactive still displays its status as running in `/etc/init.d/<service> status`.

To fix this issue, Instead of just displaying the service status as running, it needs a check if at least one of the service instances running status is true.